### PR TITLE
First cli iteration

### DIFF
--- a/scality_manila_utils/__init__.py
+++ b/scality_manila_utils/__init__.py
@@ -12,3 +12,5 @@
 # implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+__version__ = "1.0"

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -35,7 +35,7 @@ def setup_logger():
     Setup root log handler.
     """
     log_format = logging.Formatter(
-        '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+        '%(name)s - %(levelname)s - %(message)s'
     )
     handler = logging.handlers.SysLogHandler('/dev/log')
     handler.setLevel(logging.DEBUG)

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -19,6 +19,8 @@ import logging
 import logging.handlers
 import os
 import pwd
+import sys
+import traceback
 
 import scality_manila_utils
 
@@ -217,6 +219,8 @@ def main(args=None):
         result = parsed_args.func(helper, **command_args)
         if result is not None:
             print(result)
-    except:
+    except Exception as e:
         log.exception("Invocation failed")
-        raise
+        traceback.print_exc()
+        exit_code = getattr(e, 'EXIT_CODE', 1)
+        sys.exit(exit_code)

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -125,7 +125,8 @@ def main(args=None):
 
     command_parser = argparse.ArgumentParser(
         parents=[pre_parser],
-        description='Manila exports management'
+        description='Manila exports management',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
     subparsers = command_parser.add_subparsers(help='sub-command help')
 
@@ -224,3 +225,6 @@ def main(args=None):
         traceback.print_exc()
         exit_code = getattr(e, 'EXIT_CODE', 1)
         sys.exit(exit_code)
+
+if __name__ == '__main__':
+    main()

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -20,6 +20,8 @@ import logging.handlers
 import os
 import pwd
 
+import scality_manila_utils
+
 from scality_manila_utils.helper import Helper
 from scality_manila_utils.exceptions import EnvironmentException
 
@@ -112,6 +114,11 @@ def main(args=None):
         help='Set debug log level',
         action='store_true',
         default=False
+    )
+    pre_parser.add_argument(
+        '--version',
+        action='version',
+        version=scality_manila_utils.__version__
     )
 
     command_parser = argparse.ArgumentParser(

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -172,10 +172,20 @@ def main(args=None):
         help='Check for required binaries and running services'
     )
 
+    parser_get = subparsers.add_parser(
+        'get',
+        help='List the addresses that a filesystem is exported to'
+    )
+    parser_get.add_argument(
+        'export_name',
+        help='Filesystem to get information about'
+    )
+
     parser_create.set_defaults(func=Helper.add_export)
     parser_grant.set_defaults(func=Helper.grant_access)
     parser_revoke.set_defaults(func=Helper.revoke_access)
     parser_check.set_defaults(func=Helper.verify_environment)
+    parser_get.set_defaults(func=Helper.get_export)
 
     parsed_args = command_parser.parse_args(args)
 
@@ -204,7 +214,9 @@ def main(args=None):
     )
     log.info("Invoking %s(%s)", parsed_args.func.__name__, formatted_args)
     try:
-        parsed_args.func(helper, **command_args)
+        result = parsed_args.func(helper, **command_args)
+        if result is not None:
+            print(result)
     except:
         log.exception("Invocation failed")
         raise

--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import grp
+import os
+import pwd
+
+from scality_manila_utils.helper import Helper
+
+
+def drop_privileges():
+    """
+    Attempt to drop privileges.
+    """
+    def _try_get(f, *args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except KeyError:
+            return None
+
+    def get_user(name):
+        return _try_get(pwd.getpwnam, name)
+
+    def get_group(name):
+        return _try_get(grp.getgrnam, name)
+
+    # Attempt to find a proper user and group
+    user_info = get_user('nobody')
+    candidate_groups = ('nogroup', 'nobody')
+    for group in candidate_groups:
+        group_info = get_group(group)
+        if group_info is not None:
+            break
+
+    # Drop privileges
+    if user_info and group_info:
+        previous_gid = os.getegid()
+        os.setegid(group_info.gr_gid)
+        try:
+            os.seteuid(user_info.pw_uid)
+        except Exception:
+            # Attempt to restore effective gid
+            try:
+                os.setegid(previous_gid)
+            except OSError:
+                # Don't mask the previous exception
+                pass
+
+            raise
+
+    else:
+        raise RuntimeError("Unable to find an unprivilged user/group")
+
+
+def main(args=None):
+    if os.getuid() != 0:
+        raise RuntimeError("This program requires superuser privileges")
+
+    # Drop any elevated permissions
+    drop_privileges()
+
+    pre_parser = argparse.ArgumentParser(add_help=False)
+    pre_parser.add_argument(
+        '--exports',
+        help='Path to exports file',
+        default='/etc/exports.conf'
+    )
+    pre_parser.add_argument(
+        '--root-export',
+        help='NFS export path to the ring NFS root volume',
+        default='127.0.0.1:/'
+    )
+
+    command_parser = argparse.ArgumentParser(
+        parents=[pre_parser],
+        description='Manila exports management'
+    )
+    subparsers = command_parser.add_subparsers(help='sub-command help')
+
+    parser_create = subparsers.add_parser(
+        'create',
+        help='Prepare an export without any access grants'
+    )
+    parser_create.add_argument(
+        'export_name',
+        help='Export point to create'
+    )
+
+    parser_grant = subparsers.add_parser(
+        'grant',
+        help='Grant access to an existing filesystem, and reexport it'
+    )
+    parser_grant.add_argument(
+        'export_name',
+        help='Filesystem to grant access to'
+    )
+    parser_grant.add_argument(
+        'host',
+        help='IP address or network to grant access for'
+    )
+    parser_grant.add_argument(
+        'options',
+        help='Export options',
+        nargs='*'
+    )
+
+    parser_revoke = subparsers.add_parser(
+        'revoke',
+        help='Revoke access from an existing filesystem, and reexport it'
+    )
+    parser_revoke.add_argument(
+        'export_name',
+        help='Filesystem to revoke access from'
+    )
+    parser_revoke.add_argument(
+        'host',
+        help='IP address or network to revoke access for'
+    )
+
+    parser_check = subparsers.add_parser(
+        'check',
+        help='Check for required binaries and running services'
+    )
+
+    parser_create.set_defaults(func=Helper.add_export)
+    parser_grant.set_defaults(func=Helper.grant_access)
+    parser_revoke.set_defaults(func=Helper.revoke_access)
+    parser_check.set_defaults(func=Helper.verify_environment)
+
+    parsed_args = command_parser.parse_args(args)
+
+    helper = Helper(parsed_args.root_export, parsed_args.exports)
+
+    command_args = dict(
+        (k, v) for k, v in vars(parsed_args).items()
+        if k not in ('exports', 'root_export', 'func')
+    )
+    parsed_args.func(helper, **command_args)

--- a/scality_manila_utils/exceptions.py
+++ b/scality_manila_utils/exceptions.py
@@ -24,3 +24,8 @@ class ExportException(Exception):
 
 class EnvironmentException(Exception):
     """Raised when required processes and binaries are not present."""
+
+
+class ExportNotFoundException(ExportException):
+    """Raised when an export is not found."""
+    EXIT_CODE = 10

--- a/scality_manila_utils/exceptions.py
+++ b/scality_manila_utils/exceptions.py
@@ -29,3 +29,13 @@ class EnvironmentException(Exception):
 class ExportNotFoundException(ExportException):
     """Raised when an export is not found."""
     EXIT_CODE = 10
+
+
+class ClientExistsException(ExportException):
+    """Raised when a client is already granted access to an export."""
+    EXIT_CODE = 11
+
+
+class ClientNotFoundException(ExportException):
+    """Raised when a permission is not defined for an export."""
+    EXIT_CODE = 12

--- a/scality_manila_utils/exceptions.py
+++ b/scality_manila_utils/exceptions.py
@@ -20,3 +20,7 @@ class DeserializationException(ValueError):
 
 class ExportException(Exception):
     """Raised on errors pertaining to management of exports."""
+
+
+class EnvironmentException(Exception):
+    """Raised when required processes and binaries are not present."""

--- a/scality_manila_utils/exceptions.py
+++ b/scality_manila_utils/exceptions.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class DeserializationException(ValueError):
+    """Raised on deserialization failure of an exports file."""
+
+
+class ExportException(Exception):
+    """Raised on errors pertaining to management of exports."""

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -17,7 +17,10 @@ import logging
 import re
 
 from scality_manila_utils.exceptions import (ExportException,
-                                             DeserializationException)
+                                             DeserializationException,
+                                             ExportNotFoundException,
+                                             ClientExistsException,
+                                             ClientNotFoundException)
 
 log = logging.getLogger(__name__)
 
@@ -63,8 +66,8 @@ class ExportTable(object):
         else:
             clients = self.exports[export_point].clients
             if host in clients:
-                raise ExportException("Client '{0:s}' is already defined for "
-                                      "this export".format(host))
+                raise ClientExistsException("Client '{0:s}' is already "
+                                            "defined".format(host))
             clients[host] = export_options
             export = Export(export_point, clients)
             log.debug("Export updated: %r", export)
@@ -83,13 +86,14 @@ class ExportTable(object):
         :type host: string (unicode)
         """
         if export_point not in self.exports:
-            raise ExportException("No export point found for '{0:s}'".format(
-                                  export_point))
+            raise ExportNotFoundException("No export point found for "
+                                          "'{0:s}'".format(export_point))
 
         export = self.exports[export_point]
         if host not in export.clients:
-            raise ExportException("'{0:s}' has no access defined for "
-                                  "'{1:s}'".format(export_point, host))
+            raise ClientNotFoundException("'{0:s}' has no access defined "
+                                              "for '{1:s}'".format(
+                                              export_point, host))
 
         clients = export.clients
         # If there are still clients after removal,

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -149,6 +149,10 @@ class ExportTable(object):
         else:
             return NotImplemented
 
+    def __repr__(self):
+        exports = (repr(export) for export in self.exports.values())
+        return "ExportTable([{0:s}])".format(", ".join(exports))
+
 
 class Export(object):
     """
@@ -249,3 +253,8 @@ class Export(object):
             return not eq
         else:
             return NotImplemented
+
+    def __repr__(self):
+        return "Export(export_point='{0:s}', clients={1!s})".format(
+            self.export_point, self.clients
+        )

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -13,10 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import re
 
 from scality_manila_utils.exceptions import (ExportException,
                                              DeserializationException)
+
+log = logging.getLogger(__name__)
 
 
 class ExportTable(object):
@@ -56,6 +59,7 @@ class ExportTable(object):
 
         if export_point not in self.exports:
             export = Export(export_point, {host: export_options})
+            log.debug("Export created: %r", export)
         else:
             clients = self.exports[export_point].clients
             if host in clients:
@@ -63,6 +67,7 @@ class ExportTable(object):
                                       "this export".format(host))
             clients[host] = export_options
             export = Export(export_point, clients)
+            log.debug("Export updated: %r", export)
 
         self.exports[export_point] = export
 
@@ -95,6 +100,8 @@ class ExportTable(object):
         # Otherwise remove the export
         else:
             del self.exports[export_point]
+
+        log.debug("'%s' revoked from export '%s'", host, export_point)
 
     @classmethod
     def deserialize(cls, export_content):

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -135,6 +135,20 @@ class ExportTable(object):
             export.serialize() for export in self.exports.values()
         ) + '\n'
 
+    def __eq__(self, other):
+        if not isinstance(other, ExportTable):
+            return NotImplemented
+
+        return self.exports == other.exports
+
+    def __ne__(self, other):
+        eq = self.__eq__(other)
+
+        if isinstance(eq, bool):
+            return not eq
+        else:
+            return NotImplemented
+
 
 class Export(object):
     """
@@ -220,3 +234,18 @@ class Export(object):
             clients=clients,
         )
         return export_line
+
+    def __eq__(self, other):
+        if not isinstance(other, Export):
+            return NotImplemented
+
+        return (self.export_point == other.export_point and
+                self.clients == other.clients)
+
+    def __ne__(self, other):
+        eq = self.__eq__(other)
+
+        if isinstance(eq, bool):
+            return not eq
+        else:
+            return NotImplemented

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -65,6 +65,16 @@ class ExportTable(object):
             if not is_blank(line)
         )
 
+    def serialize(self):
+        """
+        Serialize the `ExportTable` to a string following /etc/exports format.
+
+        :returns: string representation of the exports
+        """
+        return '\n'.join(
+            export.serialize() for export in self.exports.values()
+        ) + '\n'
+
 
 class Export(object):
     """
@@ -131,3 +141,22 @@ class Export(object):
         export_point = export_parts[0]
         clients = dict(map(client_extract, export_parts[1:]))
         return cls(export_point, clients)
+
+    def serialize(self):
+        """
+        Serialize this `Export` to an /etc/exports representation.
+
+        :returns: a string in /etc/exports format
+        """
+        clients = ''
+        for host, options in self.clients.items():
+            clients += ' ' + host
+            if options:
+                clients += '({0:s})'.format(','.join(options))
+
+        # Attempt to align clients by padding with space up to col32
+        export_line = '{export_point:<32s} {clients:s}'.format(
+            export_point=self.export_point,
+            clients=clients,
+        )
+        return export_line

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -91,9 +91,8 @@ class ExportTable(object):
 
         export = self.exports[export_point]
         if host not in export.clients:
-            raise ClientNotFoundException("'{0:s}' has no access defined "
-                                              "for '{1:s}'".format(
-                                              export_point, host))
+            raise ClientNotFoundException("'{0:s}' has no access defined for "
+                                          "'{1:s}'".format(export_point, host))
 
         clients = export.clients
         # If there are still clients after removal,

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -160,6 +160,12 @@ class ExportTable(object):
         exports = (repr(export) for export in self.exports.values())
         return "ExportTable([{0:s}])".format(", ".join(exports))
 
+    def __getitem__(self, key):
+        return self.exports[key]
+
+    def __contains__(self, item):
+        return item in self.exports
+
 
 class Export(object):
     """

--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+
+from scality_manila_utils.exceptions import (ExportException,
+                                             DeserializationException)
+
+
+class ExportTable(object):
+    """
+    A set of exports that can be distilled into /etc/exports.
+    """
+    def __init__(self, exports):
+        """
+        Create a new exports table from the given exports.
+
+        :param exports: iterable of exports
+        :type exports: iterable of
+            :py:class:`scality_manila_utils.export.Export`
+        """
+        self.exports = dict(
+            (export.export_point, export)
+            for export in exports
+        )
+
+    @classmethod
+    def deserialize(cls, export_content):
+        """
+        Create an `ExportTable` from the contents of an /etc/exports file.
+
+        Each line of the exports file will be represented by a
+        :py:class:`scality_manila_utils.exports.Export`. Lines consisting of
+        whitespace only or that are comments will be ignored.
+
+        :param export_content: exports file contents split into a list of
+            strings
+        :type export_content: list of strings
+        :returns: a :py:class`scality_manila_utils.exports.ExportTable` object
+            with the exported filesystems
+        """
+        def strip_comment(line):
+            export, _, _ = line.partition('#')
+            return export
+
+        def is_blank(line):
+            stripped = line.strip()
+            return stripped == '' or stripped.startswith('#')
+
+        return cls(
+            Export.deserialize(strip_comment(line))
+            for line in export_content
+            if not is_blank(line)
+        )
+
+
+class Export(object):
+    """
+    Represents an exported filesystem, i.e. a single line in /etc/exports.
+    """
+    __slots__ = ('export_point', 'clients')
+
+    # Naive pattern, matching anything similar to an ip, hostname with wildcard
+    # combinations followed by optional mount options
+    CLIENT_PATTERN = re.compile(
+        r'^(?P<host>[a-z0-9*.-/]+)([(](?P<options>.+)[)])?$'
+    )
+
+    def __init__(self, export_point, clients):
+        """
+        :param export_point: the export point or filesystem
+        :type export_point: string (unicode)
+        :param clients: a mapping from hostname/network to a set of export
+            options
+        :type clients: dict
+        """
+        # Exported filesystem
+        self.export_point = export_point
+
+        # Hosts, networks allowed to mount the filesystem and corresponding
+        # export options
+        if not clients:
+            raise ExportException('An export must have at least one client')
+        self.clients = clients
+
+    @classmethod
+    def deserialize(cls, line):
+        """
+        Deserialize a line of an /etc/exports file.
+
+        A line contains an export point and a whitespace-separated list of
+        clients allowed to mount the file system at that point;
+            <export> <host1>(<options>) <host2>(<options>)...
+
+        :param line: a line in /etc/exports format
+        :type line: string (unicode)
+        :returns: :py:class:`scality_manila_utils.export.Export` instance
+        """
+        def client_extract(client):
+            match = cls.CLIENT_PATTERN.match(client)
+            if match is None:
+                msg = "Unable to parse client from {0:s}".format(client)
+                raise DeserializationException(msg)
+
+            host = match.group('host')
+            option_list = match.group('options')
+            if option_list is None:
+                options = frozenset()
+            else:
+                options = frozenset(option_list.split(','))
+            return host, options
+
+        export_parts = line.split()
+
+        if len(export_parts) < 2:
+            msg = "'{0:s}' is not a valid export line".format(line)
+            raise DeserializationException(msg)
+
+        export_point = export_parts[0]
+        clients = dict(map(client_extract, export_parts[1:]))
+        return cls(export_point, clients)

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -107,6 +107,7 @@ class Helper(object):
         :param export_name: name of export to remove
         :type export_name: string (unicode)
         """
+        raise NotImplementedError
 
     def grant_access(self, export_name, host, options):
         """

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -19,7 +19,8 @@ import os.path
 
 from scality_manila_utils import utils
 from scality_manila_utils.export import ExportTable
-from scality_manila_utils.exceptions import EnvironmentException
+from scality_manila_utils.exceptions import (EnvironmentException,
+                                             ExportException)
 
 
 class Helper(object):
@@ -74,6 +75,16 @@ class Helper(object):
         :param export_name: name of export
         :type export_name: string (unicode)
         """
+        if not export_name or '/' in export_name:
+            raise ExportException('Invalid export name')
+
+        with utils.elevated_privileges():
+            with utils.nfs_mount(self.root_volume) as root:
+                export_point = os.path.join(root, export_name)
+
+                # Create export directory if it does not already exist
+                if not os.path.exists(export_point):
+                    os.mkdir(export_point, 0o777)
 
     def wipe_export(self, export_name):
         """

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -98,7 +98,8 @@ class Helper(object):
 
                 # Create export directory if it does not already exist
                 if not os.path.exists(export_point):
-                    os.mkdir(export_point, 0o777)
+                    os.mkdir(export_point)
+                    os.chmod(export_point, 0o0777)
 
     def wipe_export(self, export_name):
         """

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -16,6 +16,7 @@
 import io
 import os
 import os.path
+import signal
 
 from scality_manila_utils import utils
 from scality_manila_utils.export import ExportTable
@@ -67,6 +68,14 @@ class Helper(object):
         """
         Export all defined filesystems.
         """
+        exports_data = self.exports.serialize()
+        sfused_pids = utils.find_pids('sfused')
+
+        with utils.elevated_privileges():
+            utils.safe_write(exports_data, self.exports_path)
+            for pid in sfused_pids:
+                log.debug('Killing sfused pid %d', pid)
+                os.kill(pid, signal.SIGHUP)
 
     def add_export(self, export_name):
         """

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -119,10 +119,8 @@ class Helper(object):
         :param options: sequence of nfs options
         :type options: iterable of strings (unicode)
         """
-        with utils.elevated_privileges():
-            with utils.nfs_mount(self.root_volume) as root:
-                if not os.path.exists(os.path.join(root, export_name)):
-                    raise ExportException("No export point found for "
+        if export_name not in self._get_exports():
+            raise ExportNotFoundException("No export point found for "
                                           "'{0:s}'".format(export_name))
 
         export_point = os.path.join('/', export_name)
@@ -161,8 +159,8 @@ class Helper(object):
             # Export has been created, but without any access grants
             clients = {}
         else:
-            msg = "Export '{0:s}' not found".format(export_name)
-            raise exceptions.ExportNotFoundException(msg)
+            raise ExportNotFoundException("Export '{0:s}' not found".format(
+                                          export_name))
 
         return json.dumps(clients)
 

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -105,6 +105,15 @@ class Helper(object):
         :param options: sequence of nfs options
         :type options: iterable of strings (unicode)
         """
+        with utils.elevated_privileges():
+            with utils.nfs_mount(self.root_volume) as root:
+                if not os.path.exists(os.path.join(root, export_name)):
+                    raise ExportException("No export point found for "
+                                          "'{0:s}'".format(export_name))
+
+        export_point = os.path.join('/', export_name)
+        self.exports.add_client(export_point, host, options)
+        self._reexport()
 
     def revoke_access(self, export_name, host):
         """
@@ -115,6 +124,9 @@ class Helper(object):
         :param host: host to revoke access for
         :type host: string (unicode)
         """
+        export_point = os.path.join('/', export_name)
+        self.exports.remove_client(export_point, host)
+        self._reexport()
 
     def get_export(self, export_name):
         """

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+class Helper(object):
+    """
+    Handles addition, removal of exports as well as client permissions.
+    """
+
+    def __init__(self, root_volume, exports_path):
+        """
+        Create a new Helper instance operating on the given exports file.
+
+        :param root_volume: root volume exported by the sfused nfs connector
+        :type root_volume: string (unicode)
+        :param exports_path: path to nfs exports file
+        :type exports_path: string (unicode)
+        """
+
+    def verify_environment(self):
+        """
+        Preliminary checks for installed binaries and running services.
+        """
+
+    def _reexport(self):
+        """
+        Export all defined filesystems.
+        """
+
+    def add_export(self, export_name):
+        """
+        Add an export.
+
+        :param export_name: name of export
+        :type export_name: string (unicode)
+        """
+
+    def wipe_export(self, export_name):
+        """
+        Remove an export.
+
+        :param export_name: name of export to remove
+        :type export_name: string (unicode)
+        """
+
+    def grant_access(self, export_name, host, options):
+        """
+        Grant access for a host to an export.
+
+        :param export_name: name of export to grant access to
+        :type export_name: string (unicode)
+        :param host: host to grant access for
+        :type host: string (unicode)
+        :param options: sequence of nfs options
+        :type options: iterable of strings (unicode)
+        """
+
+    def revoke_access(self, export_name, host):
+        """
+        Revoke access for a host to an export.
+
+        :param export_name: name of export for revocation
+        :type export_name: string (unicode)
+        :param host: host to revoke access for
+        :type host: string (unicode)
+        """
+
+    def get_export(self, export_name):
+        """
+        Retrieve client details of an export.
+
+        :param export_name: name of export
+        :type export_name: string (unicode)
+        """

--- a/scality_manila_utils/utils.py
+++ b/scality_manila_utils/utils.py
@@ -64,7 +64,7 @@ def find_pids(process):
     :returns: list of pids
     """
     process_pids = []
-    pids = filter(lambda f: f.isdigit(), os.listdir('/proc'))
+    pids = [f for f in os.listdir('/proc') if f.isdigit()]
     for pid in pids:
         status_path = os.path.join('/proc', pid, 'status')
         try:

--- a/scality_manila_utils/utils.py
+++ b/scality_manila_utils/utils.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def elevated_privileges():
+    """
+    Obtain temporary root privileges.
+    """
+    previous_uid = os.geteuid()
+    previous_gid = os.getegid()
+    # Become root
+    os.seteuid(0)
+    try:
+        os.setegid(0)
+    except OSError:
+        os.setegid(previous_gid)
+        raise
+
+    try:
+        yield
+
+    finally:
+        # Drop root privileges
+        try:
+            os.setegid(previous_gid)
+        finally:
+            os.seteuid(previous_uid)

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,10 @@ classifier =
 packages =
     scality_manila_utils
 
+[entry_points]
+console_scripts =
+    scality-manila-utils = scality_manila_utils.cli:main
+
 [nosetests]
 verbosity = 2
 detailed-errors = true

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 nose
 coverage
+hypothesis
 mock<1.1
 unittest2

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,4 @@
 nose
 coverage
+mock<1.1
+unittest2

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/unit/__init__.py
+++ b/test/unit/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -32,6 +32,7 @@ class TestCli(unittest.TestCase):
             'grant_access.__name__': 'grant_access',
             'revoke_access.__name__': 'revoke_access',
             'verify_environment.__name__': 'verify_environment',
+            'get_export.__name__': 'get_export',
         }
         patcher = mock.patch('scality_manila_utils.cli.Helper', **attrs)
         self.addCleanup(patcher.stop)
@@ -94,6 +95,17 @@ class TestCli(unittest.TestCase):
 
         scality_manila_utils.cli.main(['create', export_name])
         self.helper.add_export.assert_called_once_with(
+            self.helper(),
+            export_name=export_name,
+        )
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_invoke_get(self, getuid, drop_privileges):
+        export_name = 'share'
+
+        scality_manila_utils.cli.main(['get', export_name])
+        self.helper.get_export.assert_called_once_with(
             self.helper(),
             export_name=export_name,
         )

--- a/test/unit/test_cli.py
+++ b/test/unit/test_cli.py
@@ -1,0 +1,124 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import grp
+import mock
+import pwd
+import unittest2 as unittest
+
+import scality_manila_utils.cli
+
+
+class TestCli(unittest.TestCase):
+    group_nobody = grp.struct_group(('nogroup', 'x', 65534, []))
+    user_nobody = pwd.struct_passwd(('nobody', 'x', 99, 99,
+                                     'nobody', '/', '/usr/sbin/nologin'))
+
+    def setUp(self):
+        attrs = {
+            'add_export.__name__': 'add_export',
+            'grant_access.__name__': 'grant_access',
+            'revoke_access.__name__': 'revoke_access',
+            'verify_environment.__name__': 'verify_environment',
+        }
+        patcher = mock.patch('scality_manila_utils.cli.Helper', **attrs)
+        self.addCleanup(patcher.stop)
+        self.helper = patcher.start()
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_setup(self, getuid, drop_privileges):
+        exports = '/etc/exports'
+        root_export = 'localhost:/'
+        args = ['--exports', exports, '--root-export', root_export, 'check']
+
+        scality_manila_utils.cli.main(args)
+        drop_privileges.called_once_with()
+        self.helper.assert_called_once_with(root_export, exports)
+
+        # Non-root invocation
+        getuid.return_value = 1000
+        with self.assertRaises(RuntimeError):
+            scality_manila_utils.cli.main(args)
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_invoke_check(self, getuid, drop_privileges):
+        scality_manila_utils.cli.main(['check'])
+        self.helper.verify_environment.assert_called_once_with(self.helper())
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_invoke_grant(self, getuid, drop_privileges):
+        export_name = 'share'
+        host = '192.168.0.100'
+        options = ['rw', 'no_root_squash']
+
+        scality_manila_utils.cli.main(['grant', export_name, host] + options)
+        self.helper.grant_access.assert_called_once_with(
+            self.helper(),
+            export_name=export_name,
+            host=host,
+            options=options
+        )
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_invoke_revoke(self, getuid, drop_privileges):
+        export_name = 'share'
+        host = '192.168.0.100'
+
+        scality_manila_utils.cli.main(['revoke', export_name, host])
+        self.helper.revoke_access.assert_called_once_with(
+            self.helper(),
+            export_name=export_name,
+            host=host,
+        )
+
+    @mock.patch('scality_manila_utils.cli.drop_privileges')
+    @mock.patch('os.getuid', return_value=0)
+    def test_invoke_create(self, getuid, drop_privileges):
+        export_name = 'share'
+
+        scality_manila_utils.cli.main(['create', export_name])
+        self.helper.add_export.assert_called_once_with(
+            self.helper(),
+            export_name=export_name,
+        )
+
+    @mock.patch('grp.getgrnam')
+    @mock.patch('pwd.getpwnam')
+    @mock.patch('os.setegid')
+    @mock.patch('os.seteuid')
+    def test_drop_privileges(self, seteuid, setegid, pwd, grp):
+        # No user found
+        grp.side_effect = lambda user: self.group_nobody
+        pwd.side_effect = KeyError
+        with self.assertRaises(RuntimeError):
+            scality_manila_utils.cli.drop_privileges()
+
+        # No group found
+        grp.side_effect = KeyError
+        pwd.side_effect = lambda user: self.user_nobody
+        with self.assertRaises(RuntimeError):
+            scality_manila_utils.cli.drop_privileges()
+
+        # Unprivileged user and group found
+        grp.side_effect = lambda user: self.group_nobody
+        pwd.side_effect = lambda user: self.user_nobody
+
+        scality_manila_utils.cli.drop_privileges()
+        setegid.assert_called_once_with(self.group_nobody.gr_gid)
+        seteuid.assert_called_once_with(self.user_nobody.pw_uid)

--- a/test/unit/test_export.py
+++ b/test/unit/test_export.py
@@ -1,0 +1,176 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    from hypothesis import given, Settings
+    from hypothesis.strategies import (builds, dictionaries, integers, lists,
+                                       one_of, sampled_from, sets, text)
+except ImportError:
+    pass
+
+import sys
+import unittest2 as unittest
+
+from scality_manila_utils.export import Export, ExportTable
+
+
+class ExportStrategy(object):
+    @classmethod
+    def export_table(cls):
+        """
+        Strategy for :py:class:`scality_manila_utils.export.ExportTable`.
+        """
+        exports = lists(cls.export(), max_size=50)
+        return builds(ExportTable, exports)
+
+    @classmethod
+    def export(cls):
+        """
+        Strategy that generates :py:class:`scality_manila_utils.export.Export`.
+        """
+        export_point = cls.path()
+        host = cls.host()
+        options = sets(cls.options(), average_size=3)
+        clients = dictionaries(
+            keys=host,
+            values=options,
+            min_size=1,
+            average_size=5
+        )
+        return builds(Export, export_point, clients)
+
+    @classmethod
+    def export_line(cls):
+        """
+        Strategy that generates nfs export lines.
+        """
+        def format_export(path, clients):
+            return '{0:s} {1:s}'.format(path, ' '.join(clients))
+
+        path = cls.path()
+        clients = lists(cls.client(), min_size=1)
+        return builds(format_export, path, clients)
+
+    @classmethod
+    def client_string(cls):
+        """
+        Strategy for generation of nfs clients.
+        """
+        def format_client(host, options):
+            return '{0:s}{1:s}'.format(host, options)
+
+        host = cls.host()
+        options = cls.options_string()
+        return builds(format_client, host, options)
+
+    @classmethod
+    def options_string(cls):
+        """
+        Strategy for generation of nfs options formatted for an exports line.
+        """
+        def format_options(opts):
+            if not opts:
+                return ''
+            else:
+                return '({0:s})'.format(','.join(opts))
+
+        options = cls.options()
+        return builds(format_options, sets(options))
+
+    @classmethod
+    def options(cls):
+        """
+        Strategy for generation of nfs export options.
+        """
+        return sampled_from(('secure', 'rw', 'ro', 'sync', 'async',
+                             'no_wdelay', 'no_wdelay', 'no_subtree_check',
+                             'subtree_check', 'crossmnt', 'no_auth_nlm',
+                             'fsid=num', 'fsid=root', 'fsid=uuid', 'anonuid',
+                             'anongid', 'root_squash', 'no_root_squash',
+                             'all_squash'))
+
+    @classmethod
+    def host(cls):
+        """
+        Strategy for generation of an ip, network, or hostname
+        """
+        return one_of(cls.ip(), cls.network(), cls.hostname())
+
+    @classmethod
+    def ip(cls):
+        """
+        Strategy for IP generation.
+        """
+        def format_ip(o1, o2, o3, o4):
+            return '{:d}.{:d}.{:d}.{:d}'.format(o1, o2, o3, o4)
+
+        octet = integers(1, 254)
+        return builds(format_ip, octet, octet, octet, octet)
+
+    @classmethod
+    def network(cls):
+        """
+        Strategy for generation of networks in CIDR notation.
+        """
+        def format_network(ip, routing_prefix):
+            return '{0:s}/{1:d}'.format(ip, routing_prefix)
+
+        routing_prefix = integers(0, 32)
+        return builds(format_network, cls.ip(), routing_prefix)
+
+    @classmethod
+    def hostname(cls):
+        """
+        Strategy for hostname generation.
+        """
+        return text(cls.a_z(), min_size=1, average_size=10)
+
+    @classmethod
+    def path(cls):
+        """
+        Strategy for path name generation.
+        """
+        alphabet = one_of(cls.A_Z(), cls.a_z(), cls.numbers(),
+                          cls.punctuation())
+        # Create an absolute path from the alphabet by prepending a '/'
+        return text(alphabet, average_size=20).map(lambda s: '/' + s)
+
+    @classmethod
+    def A_Z(cls):
+        """
+        Strategy for generation of capital letters through 'A' to 'Z'.
+        """
+        return sampled_from(map(lambda c: chr(c), range(65, 91)))
+
+    @classmethod
+    def a_z(cls):
+        """
+        Strategy for generation of lowercase letters through 'a' to 'z'.
+        """
+        return sampled_from(map(lambda c: chr(c), range(97, 123)))
+
+    @classmethod
+    def numbers(cls):
+        """
+        Strategy for generation of digits.
+        """
+        return sampled_from(map(lambda n: str(n), range(10)))
+
+    @classmethod
+    def punctuation(cls):
+        """
+        Strategy for generation of punctuation characters.
+        """
+        return sampled_from(('.', '_', '/', ',', '-'))

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -1,0 +1,228 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import io
+import os
+import shutil
+import signal
+import tempfile
+import unittest2 as unittest
+
+import mock
+
+from scality_manila_utils.helper import Helper
+from scality_manila_utils.exceptions import (EnvironmentException,
+                                             ExportException)
+
+
+class TestHelper(unittest.TestCase):
+    def setUp(self):
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.close()
+        self.exports_file = f.name
+        self.root_export = '127.0.0.1:/'
+        self.helper = Helper(self.root_export, self.exports_file)
+        self.nfs_root = tempfile.mkdtemp()
+
+        attrs = {'return_value.__enter__.return_value': self.nfs_root}
+        nfs_mount_patcher = mock.patch('scality_manila_utils.utils.nfs_mount',
+                                       **attrs)
+        self.addCleanup(nfs_mount_patcher.stop)
+        self.nfs_mount_mock = nfs_mount_patcher.start()
+
+        elevated_privileges_patcher = mock.patch(
+            'scality_manila_utils.utils.elevated_privileges'
+        )
+        self.addCleanup(elevated_privileges_patcher.stop)
+        self.elevated_privileges_mock = elevated_privileges_patcher.start()
+
+    def tearDown(self):
+        os.unlink(self.exports_file)
+        shutil.rmtree(self.nfs_root)
+
+    def test_helper_instantiation(self):
+        with mock.patch('os.path.exists', return_value=False):
+            with self.assertRaises(EnvironmentException):
+                Helper("127.0.0.1:/", "/no/exports")
+
+    def test_verify_environment(self):
+        with mock.patch('scality_manila_utils.utils.binary_check') as bc:
+            with mock.patch('scality_manila_utils.utils.process_check') as pc:
+                with mock.patch('os.getenv', return_value='/a:/b'):
+                    self.helper.verify_environment()
+                    bc.has_calls((
+                        mock.call('rpcbind', ['/a', '/b']),
+                        mock.call('sfused', ['/a', '/b']),
+                    ))
+                    pc.has_calls((
+                        mock.call('rpcbind'),
+                        mock.call('sfused'),
+                    ))
+
+        with mock.patch('os.getenv', return_value='/foo:/bar'):
+            with self.assertRaises(EnvironmentException):
+                self.helper.verify_environment()
+
+    def test_add_export_invalid(self):
+        # Invalid share name checks
+        with self.assertRaises(ExportException):
+            self.helper.add_export('../directory/outside/share/root')
+            self.helper.add_export('directory/in/another/share')
+            self.helper.add_export('')
+
+    def test_add_export(self):
+        export_name = 'test'
+        absolute_export_path = os.path.join(self.nfs_root, export_name)
+        self.assertFalse(os.path.exists(absolute_export_path))
+
+        self.helper.add_export(export_name)
+        self.assertTrue(os.path.exists(absolute_export_path))
+        self.elevated_privileges_mock.assert_called_once_with()
+        self.nfs_mount_mock.assert_called_once_with(self.root_export)
+
+        # Assert that no permissions were created for the new share
+        self.assertEqual(len(self.helper.exports.exports), 0)
+
+    @mock.patch.object(Helper, '_reexport')
+    def test_grant_access_invalid(self, reexport):
+        export_name = 'grant_twice'
+        host = 'hostname'
+        self.helper.add_export(export_name)
+        self.helper.grant_access(export_name, host, [])
+
+        with self.assertRaises(ExportException):
+            self.helper.grant_access('unadded_share', host, None)
+
+            # Attempt granting access to the same export for a client twice
+            self.helper.grant_access(export_name, host, ['rw'])
+
+    @mock.patch.object(Helper, '_reexport')
+    def test_grant_access(self, reexport):
+        export_name = 'test'
+        host = 'hostname'
+        options = set(['rw'])
+
+        # Add an export
+        self.helper.add_export(export_name)
+        self.nfs_mount_mock.reset_mock()
+        self.elevated_privileges_mock.reset_mock()
+
+        # Grant access to it
+        self.helper.grant_access(export_name, host, options)
+        self.nfs_mount_mock.assert_called_once_with(self.root_export)
+        self.elevated_privileges_mock.assert_called_once_with()
+        reexport.assert_called_once_with()
+
+        self.nfs_mount_mock.reset_mock()
+        self.elevated_privileges_mock.reset_mock()
+        reexport.reset_mock()
+
+        exports = self.helper.exports.exports
+        export_point = os.path.join('/', export_name)
+        self.assertIn(export_point, exports)
+        self.assertIn(host, exports[export_point].clients)
+        self.assertEqual(exports[export_point].clients[host], options)
+
+        # Grant access to another client on the previously added export
+        host = '10.0.0.0/16'
+        self.helper.grant_access(export_name, host, None)
+        self.nfs_mount_mock.assert_called_once_with(self.root_export)
+        self.elevated_privileges_mock.assert_called_once_with()
+        reexport.assert_called_once_with()
+        self.assertIn(host, exports[export_point].clients)
+        self.assertEqual(exports[export_point].clients[host], set())
+
+    @mock.patch.object(Helper, '_reexport')
+    def test_revoke_access_invalid(self, reexport):
+        export_name = 'revoke_twice'
+        host = 'hostname'
+
+        self.helper.add_export(export_name)
+        with self.assertRaises(ExportException):
+            self.helper.revoke_access('non_existing_export', host)
+            # Export added, but has no access granted to it
+            self.helper.revoke_access(export_name, host)
+
+        self.helper.grant_access(export_name, host, ['rw'])
+        reexport.assert_called_once_with()
+        reexport.reset_mock()
+        self.helper.revoke_access(export_name, host)
+        reexport.assert_called_once_with()
+        with self.assertRaises(ExportException):
+            self.helper.revoke_access(export_name, 'ungranted_client')
+            # Test revoking access twice
+            self.helper.revoke_access(export_name, host)
+
+    @mock.patch.object(Helper, '_reexport')
+    def test_revoke_access(self, reexport):
+        export1 = 'export'
+        export2 = 'otherexport'
+        export_point1 = os.path.join('/', export1)
+        export_point2 = os.path.join('/', export2)
+        host1 = 'hostname'
+        host2 = '192.168.0.1'
+        host3 = '192.168.100.0/24'
+        exports = self.helper.exports.exports
+
+        self.helper.add_export(export1)
+        self.helper.add_export(export2)
+
+        # Grant access for three clients to export1
+        for client in (host1, host2, host3):
+            self.helper.grant_access(export1, client, ['rw'])
+
+        self.helper.grant_access(export2, host2, ['rw'])
+        reexport.reset_mock()
+
+        # Ensure integrity of other grants when revoking access
+        self.helper.revoke_access(export1, host3)
+        reexport.assert_called_once_with()
+        self.assertNotIn(host3, exports[export_point1].clients)
+        self.assertIn(host2, exports[export_point1].clients)
+        self.assertIn(host1, exports[export_point1].clients)
+        self.assertIn(host2, exports[export_point2].clients)
+        reexport.reset_mock()
+
+        self.helper.revoke_access(export1, host2)
+        reexport.assert_called_once_with()
+        self.assertNotIn(host2, exports[export_point1].clients)
+        self.assertIn(host1, exports[export_point1].clients)
+        self.assertIn(host2, exports[export_point2].clients)
+        reexport.reset_mock()
+
+        # Check that the export is removed together with the last permission
+        self.helper.revoke_access(export1, host1)
+        reexport.assert_called_once_with()
+        self.assertNotIn(export_point1, exports)
+        self.assertIn(host2, exports[export_point2].clients)
+
+    @mock.patch('scality_manila_utils.utils.find_pids', return_value=[100])
+    @mock.patch('os.kill')
+    def test_reexport(self, kill, find_pids):
+        export_name = 'test_export'
+        expected_exports = '/test_export                      10.0.0.1(rw)\n'
+
+        # No pre-existing exports
+        self.assertEqual(os.path.getsize(self.exports_file), 0)
+
+        self.helper.add_export(export_name)
+        self.helper.grant_access(export_name, '10.0.0.1', ['rw'])
+        find_pids.assert_called_once_with('sfused')
+        kill.assert_called_once_with(100, signal.SIGHUP)
+        self.elevated_privileges_mock.assert_called_with()
+
+        # Assert that the added export has been written
+        with io.open(self.exports_file) as f:
+            self.assertEqual(f.read(), expected_exports)

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -1,0 +1,163 @@
+# Copyright (c) 2015 Scality
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+# implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import mock
+import io
+import os
+import shutil
+import stat
+import tempfile
+import unittest2 as unittest
+
+from scality_manila_utils import utils
+from scality_manila_utils.exceptions import EnvironmentException
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.test_directories = []
+
+    def tearDown(self):
+        for directory in self.test_directories:
+            shutil.rmtree(directory)
+
+    @mock.patch('os.geteuid', return_value=1000)
+    @mock.patch('os.getegid', return_value=1000)
+    @mock.patch('os.seteuid')
+    @mock.patch('os.setegid')
+    def test_elevated_privileges(self, setegid, seteuid, getegid, geteuid):
+        unprivileged_uid = os.geteuid()
+        unprivileged_gid = os.getegid()
+
+        with utils.elevated_privileges():
+            # Privileges should be elevated inside the context manager
+            seteuid.assert_called_once_with(0)
+            setegid.assert_called_once_with(0)
+            seteuid.reset_mock()
+            setegid.reset_mock()
+
+        # Privileges should be reset once outside the context manager
+        seteuid.assert_called_once_with(unprivileged_uid)
+        setegid.assert_called_once_with(unprivileged_gid)
+
+    def test_find_pids(self):
+        # Setup a directory to serve as /proc
+        proc_path = tempfile.mkdtemp()
+        self.test_directories.append(proc_path)
+        processes = ((10, 'p1'), (20, 'p2'), (30, 'p3'), (40, 'p4'))
+        for pid, process_name in processes:
+            self._create_proc_entry(proc_path, pid, process_name)
+
+        # Add some other directories under proc
+        non_processes = ('otherdir', 'noprocess', 'sys')
+        for directory in non_processes:
+            os.mkdir(os.path.join(proc_path, directory))
+
+        # Mocks for `os.listdir` and `os.path.join`
+        def listdir_mock(*args, **kwargs):
+            proc_listing = [str(pid) for pid, _ in processes]
+            proc_listing.extend(non_processes)
+            return proc_listing
+
+        def join_mock(procdir, pid, status):
+            return "/{proc:s}/{pid:s}/{status:s}".format(proc=proc_path,
+                                                         pid=pid,
+                                                         status=status)
+
+        with mock.patch('os.listdir', side_effect=listdir_mock):
+            with mock.patch('os.path.join', side_effect=join_mock):
+                for not_a_process in non_processes:
+                    self.assertEqual(utils.find_pids(not_a_process), [])
+
+                for pid, process_name in processes:
+                    self.assertEqual(utils.find_pids(process_name), [pid])
+
+    def _create_proc_entry(self, proc_path, pid, process_name):
+        pid_path = os.path.join(proc_path, str(pid))
+        os.mkdir(pid_path)
+        with io.open(os.path.join(pid_path, 'status'), 'wt') as f:
+            f.write(u'Name: {0:s}'.format(process_name))
+
+    def test_binary_check(self):
+        self.test_directories = [tempfile.mkdtemp(), tempfile.mkdtemp()]
+        binary_name = 'bin'
+
+        with self.assertRaises(EnvironmentException):
+            utils.binary_check(binary_name, [])
+            utils.binary_check('', self.test_directories)
+            utils.binary_check(binary_name, self.test_directories)
+
+        # Put the expected binary in a test directory
+        binary_path = os.path.join(self.test_directories[-1], binary_name)
+        io.open(binary_path, 'wb').close()
+        # Should be ok
+        utils.binary_check(binary_name, self.test_directories)
+
+    @mock.patch('scality_manila_utils.utils.find_pids')
+    def test_process_check(self, find_pids):
+        find_pids.return_value = []
+        process_name = 'sfused'
+
+        with self.assertRaises(EnvironmentException):
+            utils.process_check(process_name)
+
+        find_pids.assert_called_once_with(process_name)
+        find_pids.reset_mock()
+        find_pids.return_value = [100]
+        utils.process_check(process_name)
+        find_pids.assert_called_once_with(process_name)
+
+    def test_safe_write(self):
+        testdir = tempfile.mkdtemp()
+        self.test_directories.append(testdir)
+        test_file = os.path.join(testdir, 'testfile')
+        sometext = 'abc123'
+        mode = 0o444
+
+        utils.safe_write(sometext, test_file, mode)
+
+        # Check for expected permission bitmask
+        self.assertEqual(stat.S_IMODE(os.stat(test_file).st_mode), mode)
+
+        # Check contents
+        with io.open(test_file, 'rt') as f:
+            self.assertEqual(f.read(), sometext)
+
+    @mock.patch('subprocess.check_call')
+    def test_nfs_mount(self, check_call):
+        export_path = '127.0.0.1:/'
+        with utils.nfs_mount(export_path) as root:
+            self.assertTrue(os.path.exists(root))
+            check_call.assert_called_once_with(['mount', export_path, root])
+            check_call.reset_mock()
+
+        self.assertFalse(os.path.exists(root))
+        check_call.assert_called_once_with(['umount', root])
+
+        # Check that cleanup is made when an exception is raised
+        class TestException(Exception):
+            """Cleanup test exception"""
+
+        check_call.reset_mock()
+        try:
+            with utils.nfs_mount(export_path) as root:
+                self.assertTrue(os.path.exists(root))
+                check_call.assert_called_once_with(['mount', export_path,
+                                                   root])
+                check_call.reset_mock()
+                raise TestException
+        except TestException:
+            self.assertFalse(os.path.exists(root))
+            check_call.assert_called_once_with(['umount', root])

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ minversion = 1.6
 [testenv]
 deps =
     -r{toxinidir}/test-requirements.txt
-commands = nosetests []
+commands = nosetests --process-timeout=40 []
 
 [testenv:flake8]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -13,3 +13,6 @@ deps =
     flake8
 commands =
     flake8 []
+
+[flake8]
+exclude = .hypothesis/*

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,15 @@ envlist = py26, py27, py33, py34, flake8
 minversion = 1.6
 
 [testenv]
-deps =
-    -r{toxinidir}/test-requirements.txt
+deps = -r{toxinidir}/test-requirements.txt
 commands = nosetests --process-timeout=40 []
 
+[testenv:pylint]
+deps = pylint
+commands = pylint scality_manila_utils
+
 [testenv:flake8]
-deps =
-    -r{toxinidir}/test-requirements.txt
-    flake8
+deps = flake8
 commands =
     flake8 []
 


### PR DESCRIPTION
This is an implementation of the cli which will allow the Manila driver to manage nfs exports residing on the ring.

The base assumption is that this cli exists on a machine that can be accessible by openstack tenants, and the manila admin network, and has the nfs connector configured for access to an already installed and configured ring.

When access to an export for a client is granted or revoked, the exports file is modified accordingly and reexported by HUPing the sfused process.
