### PR TITLE
Support for export removal

### DIFF
--- a/scality_manila_utils/cli.py
+++ b/scality_manila_utils/cli.py
@@ -182,10 +182,20 @@ def main(args=None):
         help='Filesystem to get information about'
     )
 
+    parser_wipe = subparsers.add_parser(
+        'wipe',
+        help='Remove an existing export. The export must not have any grants.'
+    )
+    parser_wipe.add_argument(
+        'export_name',
+        help='Filesystem to remove'
+    )
+
     parser_create.set_defaults(func=scality_manila_utils.helper.add_export)
     parser_grant.set_defaults(func=scality_manila_utils.helper.grant_access)
     parser_revoke.set_defaults(func=scality_manila_utils.helper.revoke_access)
     parser_get.set_defaults(func=scality_manila_utils.helper.get_export)
+    parser_wipe.set_defaults(func=scality_manila_utils.helper.wipe_export)
     parser_check.set_defaults(
         func=scality_manila_utils.helper.verify_environment
     )

--- a/scality_manila_utils/exceptions.py
+++ b/scality_manila_utils/exceptions.py
@@ -39,3 +39,8 @@ class ClientExistsException(ExportException):
 class ClientNotFoundException(ExportException):
     """Raised when a permission is not defined for an export."""
     EXIT_CODE = 12
+
+
+class ExportHasGrantsException(ExportException):
+    """Raised when attempting to remove an export with existing clients."""
+    EXIT_CODE = 13

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -181,6 +181,10 @@ def wipe_export(root_export, exports_file, export_name):
                 log.error("Unable to rename '%s' for removal", export_name)
                 raise
 
+            # Persisting the parent of the moved directory is required, as
+            # it keeps track of its contents.
+            utils.fsync_path(root)
+
 
 @ensure_environment
 def grant_access(root_export, exports_file, export_name, host, options):

--- a/scality_manila_utils/utils.py
+++ b/scality_manila_utils/utils.py
@@ -119,6 +119,22 @@ def process_check(process):
                                    "started".format(process))
 
 
+def fsync_path(path):
+    """
+    Fsync a directory.
+
+    :param path: path to directory to fsync
+    :type path: string (unicode)
+    """
+    fd = None
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_DIRECTORY)
+        os.fsync(fd)
+    finally:
+        if fd is not None:
+            os.close(fd)
+
+
 def safe_write(text, path, permissions=0o644):
     """
     Write contents to file in a safe manner.
@@ -145,13 +161,7 @@ def safe_write(text, path, permissions=0o644):
         os.rename(f.name, path)
 
     # fsync the directory holding the file just written and moved
-    dir_fd = None
-    try:
-        dir_fd = os.open(target_dir, os.O_RDONLY)
-        os.fsync(dir_fd)
-    finally:
-        if dir_fd is not None:
-            os.close(dir_fd)
+    fsync_path(target_dir)
 
 
 @contextlib.contextmanager

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -26,7 +26,8 @@ from scality_manila_utils import helper
 from scality_manila_utils.export import ExportTable, Export
 from scality_manila_utils.exceptions import (EnvironmentException,
                                              ExportException,
-                                             ExportNotFoundException)
+                                             ExportNotFoundException,
+                                             ExportHasGrantsException)
 
 
 class TestHelper(unittest.TestCase):
@@ -370,3 +371,42 @@ class TestHelper(unittest.TestCase):
             get = helper.get_export(self.root_export, self.exports_file,
                                     export)
             self.assertEqual(get, '{"host": ["rw"]}')
+
+    @mock.patch('scality_manila_utils.helper.verify_environment')
+    def test_wipe_export_invalid(self, verify_environment):
+        export_name = 'export_with_grants'
+        host = '10.0.0.0/24'
+        export_point = os.path.join('/', export_name)
+        exports = ExportTable([
+            Export(
+                export_point=export_point,
+                clients={host: frozenset(['rw'])}
+            ),
+        ])
+
+        # Attempt to remove an export with existing grants
+        with mock.patch('scality_manila_utils.helper._get_defined_exports',
+                        return_value=exports):
+            with self.assertRaises(ExportHasGrantsException):
+                helper.wipe_export(self.root_export, self.exports_file,
+                                   export_name)
+
+        # Attempt to remove an export which does not exist
+        with self.assertRaises(ExportNotFoundException):
+            helper.wipe_export(self.root_export, self.exports_file, 'void')
+
+
+    @mock.patch('scality_manila_utils.helper.verify_environment')
+    def test_wipe_export(self, verify_environment):
+        export_name = "test_export"
+        absolute_export_path = os.path.join(self.nfs_root, export_name)
+        tombstone_path = os.path.join(self.nfs_root,
+                                      'TRASH-{0:s}'.format(export_name))
+
+        self.assertFalse(os.path.exists(absolute_export_path))
+        helper.add_export(self.root_export, export_name)
+        self.assertTrue(os.path.exists(absolute_export_path))
+
+        helper.wipe_export(self.root_export, self.exports_file, export_name)
+        self.assertFalse(os.path.exists(absolute_export_path))
+        self.assertTrue(os.path.exists(tombstone_path))

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -395,7 +395,6 @@ class TestHelper(unittest.TestCase):
         with self.assertRaises(ExportNotFoundException):
             helper.wipe_export(self.root_export, self.exports_file, 'void')
 
-
     @mock.patch('scality_manila_utils.helper.verify_environment')
     def test_wipe_export(self, verify_environment):
         export_name = "test_export"
@@ -407,6 +406,9 @@ class TestHelper(unittest.TestCase):
         helper.add_export(self.root_export, export_name)
         self.assertTrue(os.path.exists(absolute_export_path))
 
-        helper.wipe_export(self.root_export, self.exports_file, export_name)
-        self.assertFalse(os.path.exists(absolute_export_path))
-        self.assertTrue(os.path.exists(tombstone_path))
+        with mock.patch('scality_manila_utils.utils.fsync_path') as fsync_path:
+            helper.wipe_export(self.root_export, self.exports_file,
+                               export_name)
+            fsync_path.assert_called_once_with(self.nfs_root)
+            self.assertFalse(os.path.exists(absolute_export_path))
+            self.assertTrue(os.path.exists(tombstone_path))

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -161,3 +161,17 @@ class TestUtils(unittest.TestCase):
         except TestException:
             self.assertFalse(os.path.exists(root))
             check_call.assert_called_once_with(['umount', root])
+
+    def test_fsync_path(self):
+        fd = 10
+        path = '/'
+        with mock.patch('os.open', return_value=fd) as osopen:
+            with mock.patch('os.fsync') as fsync:
+                with mock.patch('os.close') as osclose:
+                    utils.fsync_path(path)
+                    osopen.assert_called_once_with(
+                        path,
+                        os.O_RDONLY | os.O_DIRECTORY
+                    )
+                    fsync.assert_called_once_with(fd)
+                    osclose.assert_called_once_with(fd)


### PR DESCRIPTION
This adds support for wiping an export. The export is actually not removed, but marked for removal by renaming and prefixing the directory which corresponds to the export with a `TRASH-` tag. It is then up to the administrator to remove or archive this export, either manually or by some cron facility.
