### PR TITLE
Raise proper exception on revoke attempt from an export without clients

### DIFF
--- a/scality_manila_utils/export.py
+++ b/scality_manila_utils/export.py
@@ -18,7 +18,6 @@ import re
 
 from scality_manila_utils.exceptions import (ExportException,
                                              DeserializationException,
-                                             ExportNotFoundException,
                                              ClientExistsException,
                                              ClientNotFoundException)
 
@@ -86,7 +85,7 @@ class ExportTable(object):
         :type host: string (unicode)
         """
         if export_point not in self.exports:
-            raise ExportNotFoundException("No export point found for "
+            raise ClientNotFoundException("No acl defined for "
                                           "'{0:s}'".format(export_point))
 
         export = self.exports[export_point]

--- a/scality_manila_utils/helper.py
+++ b/scality_manila_utils/helper.py
@@ -229,6 +229,10 @@ def revoke_access(root_export, exports_file, export_name, host):
     :param host: host to revoke access for
     :type host: string (unicode)
     """
+    if export_name not in _get_export_points(root_export):
+        raise ExportNotFoundException("Export '{0:s}' not found".format(
+                                      export_name))
+
     export_point = os.path.join('/', export_name)
     exports = _get_defined_exports(exports_file)
     exports.remove_client(export_point, host)

--- a/test/unit/test_helper.py
+++ b/test/unit/test_helper.py
@@ -27,7 +27,8 @@ from scality_manila_utils.export import ExportTable, Export
 from scality_manila_utils.exceptions import (EnvironmentException,
                                              ExportException,
                                              ExportNotFoundException,
-                                             ExportHasGrantsException)
+                                             ExportHasGrantsException,
+                                             ClientNotFoundException)
 
 
 class TestHelper(unittest.TestCase):
@@ -204,6 +205,9 @@ class TestHelper(unittest.TestCase):
         export_name = 'revoke'
         export_point = os.path.join('/', export_name)
         host = 'hostname'
+
+        helper.add_export(self.root_export, export_name,
+                          exports_file=self.exports_file)
         exports = ExportTable([
             Export(
                 export_point=export_point,
@@ -217,6 +221,7 @@ class TestHelper(unittest.TestCase):
                 helper.revoke_access(self.root_export, self.exports_file,
                                      'non_existing_export', host)
 
+            with self.assertRaises(ClientNotFoundException):
                 helper.revoke_access(self.root_export, self.exports_file,
                                      export_name, 'ungranted_client')
 
@@ -230,6 +235,12 @@ class TestHelper(unittest.TestCase):
         host1 = 'hostname'
         host2 = '192.168.0.1'
         host3 = '192.168.100.0/24'
+
+        # Add exports
+        for export in (export1, export2):
+            helper.add_export(self.root_export, export,
+                              exports_file=self.exports_file)
+        verify_environment.reset_mock()
 
         exports = ExportTable([
             Export(


### PR DESCRIPTION
This raises the proper exception `ClientNotFoundException` when attempting to revoke access for a client from a share that exists, but does not have an acl associated.
