### PR TITLE
Share creation: explicitely chmod the directory

### DIFF
--- a/scality_manila_utils/nfs_helper.py
+++ b/scality_manila_utils/nfs_helper.py
@@ -141,6 +141,8 @@ def add_export(root_export, export_name, *args, **kwargs):
             # Create export directory if it does not already exist
             if not os.path.exists(export_point):
                 os.mkdir(export_point)
+                # On some systems, the `mode` argument of mkdir is ignored.
+                # So be safe, and do an explicit chmod.
                 os.chmod(export_point, 0o0777)
 
 

--- a/scality_manila_utils/smb_helper.py
+++ b/scality_manila_utils/smb_helper.py
@@ -190,7 +190,10 @@ def add_export(root_export, export_name, *args, **kwargs):
 
     with utils.elevated_privileges():
         try:
-            os.mkdir(export_point, 0o0777)
+            os.mkdir(export_point)
+            # On some systems, the `mode` argument of mkdir is ignored.
+            # So be safe, and do an explicit chmod.
+            os.chmod(export_point, 0o0777)
         except OSError as exc:
             if exc.errno != errno.EEXIST:
                 raise

--- a/test/unit/test_smb_helper.py
+++ b/test/unit/test_smb_helper.py
@@ -188,13 +188,15 @@ class TestSMBHelperWithMockedVerifyEnv(BaseTestSMBHelper):
                           export_name='sla/sh', root_export=self.root_export)
 
     @mock.patch('os.mkdir')
+    @mock.patch('os.chmod')
     @mock.patch('subprocess.check_call')
-    def test_add_export(self, mock_check_call, mock_mkdir):
+    def test_add_export(self, mock_check_call, mock_chmod, mock_mkdir):
         smb_helper.add_export(export_name='test', root_export=self.root_export)
 
         export_point = os.path.join(self.root_export, 'test')
 
-        mock_mkdir.assert_called_once_with(export_point, 0o0777)
+        mock_mkdir.assert_called_once_with(export_point)
+        mock_chmod.assert_called_once_with(export_point, 0o0777)
         self.assertEqual(6, mock_check_call.call_count)
         self.elevated_privileges_mock.assert_called_once_with()
         self.mock_verify_environment.assert_called_once_with(self.root_export)


### PR DESCRIPTION
We shouldn't rely on the `mode` argument of `os.mkdir`, some systems
ignore this argument. Do an explicit `os.chmod` instead.
